### PR TITLE
Unit test infrastructure

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -18,7 +18,7 @@
     ],
     "eslint/eqeqeq": ["off", "smart"],
     "eslint/func-style": ["warn", "declaration"],
-    "eslint/id-length": ["warn", { "exceptionPatterns": ["^_", "^[Trtv]$"] }],
+    "eslint/id-length": ["warn", { "exceptionPatterns": ["^_", "^[Tertv]$"] }],
     "eslint/init-declarations": "off",
     "eslint/max-params": ["warn", { "max": 4 }],
     "eslint/max-statements": ["warn", { "max": 20 }],
@@ -41,10 +41,7 @@
     "import/group-exports": "off",
     "import/no-default-export": "off",
     "import/no-named-export": "off",
-    "import/no-namespace": [
-      "error",
-      { "ignore": ["@fedify/vocab", "./schema.ts"] }
-    ],
+    "import/no-namespace": "off",
     "import/no-nodejs-modules": "off",
     "import/prefer-default-export": "off",
     "jsdoc/require-param-type": "off",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,7 @@ Use mise tasks from the repository root:
 mise run check
 mise run fmt
 mise run build
+mise run test
 mise run dev
 ~~~~
 
@@ -238,6 +239,69 @@ way that fights those tools.
 [Hongdown]: https://github.com/dahlia/hongdown
 
 
+Unit tests
+----------
+
+Test files live in the same package *src/* directory as the source they test
+and follow the `*.test.ts` naming convention.
+
+Use the built-in `node:test` runner and import `node:assert/strict` under the
+name `assert`:
+
+~~~~ ts
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+~~~~
+
+Import the module under test through its package subpath export, not through a
+relative source path:
+
+~~~~ ts
+// correct
+import { normalizeEmail } from "@drfed/models/email";
+
+// wrong — do not do this
+import { normalizeEmail } from "./email.ts";
+~~~~
+
+Using the package import exercises the built *dist/* output and catches
+discrepancies between source and what consumers actually receive.  Build the
+package before running tests (`pnpm --filter <package> run build` or
+`mise run build`).
+
+If the module under test is not yet listed as a subpath export, add it to the
+`exports` field in the package's *package.json* and to the `entry` array in
+the `tsdown` configuration before writing tests:
+
+~~~~ json
+"exports": {
+  "./email": {
+    "types": "./dist/email.d.mts",
+    "default": "./dist/email.mjs"
+  }
+},
+"tsdown": {
+  "entry": ["src/index.ts", "src/email.ts"]
+}
+~~~~
+
+Each package with tests exposes a `test` npm script that runs Node.js's
+built-in test runner:
+
+~~~~ json
+"scripts": {
+  "test": "node --test"
+}
+~~~~
+
+Run all tests across the monorepo from the repository root (builds first
+automatically):
+
+~~~~ sh
+mise run test
+~~~~
+
+
 Database changes
 ----------------
 
@@ -308,15 +372,13 @@ Before sending a pull request, run:
 ~~~~ sh
 mise run check
 mise run build
+mise run test
 ~~~~
 
 Run `mise run dev` for changes that affect startup, CLI parsing, migration
 execution, the GraphQL server, or package build output.  Manually verify the
 installed CLI behavior when changing package metadata, `bin` entries, build
 configuration, or files published to npm.
-
-There is no dedicated test suite in this repository yet.  When adding tests,
-keep them runnable from mise and make the command visible in *mise.toml*.
 
 
 Documentation guidance

--- a/mise.toml
+++ b/mise.toml
@@ -63,7 +63,12 @@ run = "mise fmt"
 
 [tasks.build]
 description = "Build the project"
-run = "pnpm run --recursive build"
+run = "pnpm run --parallel --recursive build"
+
+[tasks.test]
+description = "Run tests"
+depends = ["build"]
+run = "pnpm run --parallel --recursive test"
 
 [tasks.bump]
 description = "Bump all package versions"

--- a/packages/drfed/package.json
+++ b/packages/drfed/package.json
@@ -50,7 +50,9 @@
     "drfed-server": "bin/drfed-server.mjs"
   },
   "tsdown": {
-    "dts": true,
+    "dts": {
+      "sourcemap": true
+    },
     "sourcemap": true
   },
   "scripts": {

--- a/packages/drfed/src/index.ts
+++ b/packages/drfed/src/index.ts
@@ -25,7 +25,7 @@ import metadata from "../package.json" with { type: "json" };
 import type { Options } from "./parser.ts";
 import program from "./program.ts";
 
-export async function main() {
+export async function main(): Promise<void> {
   const options: Options = run(program, {
     help: "option",
     showChoices: true,

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -41,16 +41,48 @@
   "type": "module",
   "main": "dist/index.mjs",
   "types": "dist/index.d.mts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    },
+    "./account": {
+      "types": "./dist/account.d.mts",
+      "default": "./dist/account.mjs"
+    },
+    "./builder": {
+      "types": "./dist/builder.d.mts",
+      "default": "./dist/builder.mjs"
+    },
+    "./instance": {
+      "types": "./dist/instance.d.mts",
+      "default": "./dist/instance.mjs"
+    },
+    "./schema": {
+      "types": "./dist/schema.d.mts",
+      "default": "./dist/schema.mjs"
+    }
+  },
   "files": [
     "dist/",
     "README.md"
   ],
   "tsdown": {
-    "dts": true,
+    "entry": [
+      "src/index.ts",
+      "src/account.ts",
+      "src/builder.ts",
+      "src/instance.ts",
+      "src/schema.ts"
+    ],
+    "dts": {
+      "sourcemap": true
+    },
     "sourcemap": true
   },
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "test": "node --test"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/graphql/src/account.ts
+++ b/packages/graphql/src/account.ts
@@ -13,9 +13,9 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import builder from "./builder.ts";
+import builder, { type DrFedObjectRef } from "./builder.ts";
 
-export const Account = builder.drizzleNode("accounts", {
+const AccountRef = builder.drizzleNode("accounts", {
   description:
     "Represents an `Account` in the DrFed platform.  " +
     "Note that it differs from the ActivityPub `Actor`s that belong to `Instance`s.",
@@ -42,6 +42,8 @@ export const Account = builder.drizzleNode("accounts", {
   name: "Account",
 });
 
+export const Account: DrFedObjectRef = AccountRef;
+
 builder.queryFields((t) => ({
   accountByUuid: t.drizzleField({
     args: {
@@ -56,6 +58,6 @@ builder.queryFields((t) => ({
     resolve(query, _, { uuid }, ctx) {
       return ctx.db.query.accounts.findFirst(query({ where: { id: uuid } }));
     },
-    type: Account,
+    type: AccountRef,
   }),
 }));

--- a/packages/graphql/src/builder.ts
+++ b/packages/graphql/src/builder.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import { type Database, normalizeEmail, relations } from "@drfed/models";
-import SchemaBuilder from "@pothos/core";
+import SchemaBuilder, { type ObjectRef } from "@pothos/core";
 import DrizzlePlugin from "@pothos/plugin-drizzle";
 import RelayPlugin from "@pothos/plugin-relay";
 import { getTableConfig } from "drizzle-orm/pg-core";
@@ -62,6 +62,15 @@ export interface SchemaTypes {
   DefaultFieldNullability: false;
   DrizzleRelations: typeof relations;
 }
+
+export type DrFedSchemaTypes =
+  PothosSchemaTypes.ExtendDefaultTypes<SchemaTypes>;
+
+export type DrFedObjectRef<Shape = unknown, Parent = Shape> = ObjectRef<
+  DrFedSchemaTypes,
+  Shape,
+  Parent
+>;
 
 /**
  * The GraphQL schema builder.

--- a/packages/graphql/src/instance.ts
+++ b/packages/graphql/src/instance.ts
@@ -13,9 +13,9 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import builder from "./builder.ts";
+import builder, { type DrFedObjectRef } from "./builder.ts";
 
-export const Instance = builder.drizzleNode("instances", {
+const InstanceRef = builder.drizzleNode("instances", {
   description: "Represents an `Instance` in the DrFed platform.",
   fields: (t) => ({
     created: t.expose("created", {
@@ -36,3 +36,5 @@ export const Instance = builder.drizzleNode("instances", {
   },
   name: "Instance",
 });
+
+export const Instance: DrFedObjectRef = InstanceRef;

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -41,17 +41,54 @@
   "type": "module",
   "main": "dist/index.mjs",
   "types": "dist/index.d.mts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    },
+    "./db": {
+      "types": "./dist/db.d.mts",
+      "default": "./dist/db.mjs"
+    },
+    "./email": {
+      "types": "./dist/email.d.mts",
+      "default": "./dist/email.mjs"
+    },
+    "./migrate": {
+      "types": "./dist/migrate.d.mts",
+      "default": "./dist/migrate.mjs"
+    },
+    "./relations": {
+      "types": "./dist/relations.d.mts",
+      "default": "./dist/relations.mjs"
+    },
+    "./schema": {
+      "types": "./dist/schema.d.mts",
+      "default": "./dist/schema.mjs"
+    }
+  },
   "files": [
     "dist/",
     "drizzle/",
     "README.md"
   ],
   "tsdown": {
-    "dts": true,
+    "entry": [
+      "src/index.ts",
+      "src/db.ts",
+      "src/email.ts",
+      "src/migrate.ts",
+      "src/relations.ts",
+      "src/schema.ts"
+    ],
+    "dts": {
+      "sourcemap": true
+    },
     "sourcemap": true
   },
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "test": "node --test"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/models/src/email.test.ts
+++ b/packages/models/src/email.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { normalizeEmail } from "@drfed/models/email";
+
+describe("normalizeEmail()", () => {
+  it("with valid email", () => {
+    assert.deepEqual(normalizeEmail("test@example.com"), "test@example.com");
+    assert.deepEqual(
+      normalizeEmail("  test@example.com  "),
+      "test@example.com",
+    );
+    assert.deepEqual(normalizeEmail("Test@EXAMPLE.COM"), "Test@example.com");
+    assert.deepEqual(
+      normalizeEmail("user@中文.example"),
+      "user@xn--fiq228c.example",
+    );
+  });
+
+  it("with null and undefined", () => {
+    assert.deepEqual(normalizeEmail(null), null);
+    assert.deepEqual(normalizeEmail(undefined), undefined);
+  });
+
+  it("with invalid email", () => {
+    assert.throws(
+      () => normalizeEmail("invalid"),
+      (e) =>
+        e instanceof TypeError && e.message.includes("Invalid email format."),
+    );
+    assert.throws(
+      () => normalizeEmail("@example.com"),
+      (e) =>
+        e instanceof TypeError && e.message.includes("Invalid email format."),
+    );
+    assert.throws(
+      () => normalizeEmail("test@"),
+      (e) =>
+        e instanceof TypeError && e.message.includes("Invalid email format."),
+    );
+    assert.throws(
+      () => normalizeEmail("test@example@com"),
+      (e) =>
+        e instanceof TypeError && e.message.includes("Invalid email format."),
+    );
+  });
+});


### PR DESCRIPTION
Added the unit test infrastructure using [Node.js' built-in test runner][1]. Also added explicit subpath `exports` for `@drfed/models` and `@drfed/graphql`. See also the added section named *Unit tests* in the *CONTRIBUTING.md* for its usage.

[1]: https://nodejs.org/docs/latest/api/test.html