### PR TITLE
Add `fmt:license` and `check:license` tasks

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -29,6 +29,7 @@
     "eslint/no-eq-null": "off",
     "eslint/no-magic-numbers": "warn",
     "eslint/no-ternary": "off",
+    "eslint/no-nested-ternary": "off",
     "eslint/no-undefined": "off",
     "eslint/no-void": "off",
     "eslint/no-warning-comments": ["warn", { "terms": ["TODO"] }],

--- a/mise.toml
+++ b/mise.toml
@@ -46,6 +46,13 @@ run = "hongdown --check"
 description = "Check mise.toml formatting"
 run = "mise fmt --check"
 
+[tasks."check:license"]
+description = "Check the license comments of files in the whole codebase."
+run = """
+#!/usr/bin/env nu
+node scripts/add-license/main.mts --check
+"""
+
 [tasks."check:versions"]
 description = "Check that all package versions are in sync"
 run = "node scripts/check-versions.mts"
@@ -62,6 +69,13 @@ run = "hongdown --write"
 [tasks."fmt:mise"]
 description = "Format mise.toml"
 run = "mise fmt"
+
+[tasks."fmt:license"]
+description = "Add license comments to the files that don't have them."
+run = """
+#!/usr/bin/env nu
+node scripts/add-license/main.mts
+"""
 
 [tasks.build]
 description = "Build the project"

--- a/scripts/add-license/gpl.mts
+++ b/scripts/add-license/gpl.mts
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/scripts/add-license/gpl.mts
+++ b/scripts/add-license/gpl.mts
@@ -1,0 +1,18 @@
+import { readFile } from "node:fs/promises";
+
+const GPL = (await readFile("./gpl.txt", { encoding: "utf-8" })).split("\n");
+const JS_GPL = GPL.map((line) => `// ${line}`).join("\n");
+const CSS_GPL = ["/*", ...GPL, "*/"].join("\n");
+const GPL_BY_EXT = {
+  ts: JS_GPL,
+  tsx: JS_GPL,
+  mts: JS_GPL,
+  cts: JS_GPL,
+  js: JS_GPL,
+  jsx: JS_GPL,
+  mjs: JS_GPL,
+  cjs: JS_GPL,
+  css: CSS_GPL,
+};
+
+export default GPL_BY_EXT;

--- a/scripts/add-license/gpl.mts
+++ b/scripts/add-license/gpl.mts
@@ -1,3 +1,18 @@
+// DrFed: A web-based platform for developing and debugging ActivityPub apps
+// Copyright (C) 2026 DrFed team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/scripts/add-license/gpl.mts
+++ b/scripts/add-license/gpl.mts
@@ -1,7 +1,14 @@
 import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const GPL = (await readFile("./gpl.txt", { encoding: "utf-8" })).split("\n");
-const JS_GPL = GPL.map((line) => `// ${line}`).join("\n");
+const GPL_TXT_PATH = join(dirname(fileURLToPath(import.meta.url)), "gpl.txt");
+const GPL = (await readFile(GPL_TXT_PATH, { encoding: "utf-8" }))
+  .trimEnd()
+  .split("\n");
+const JS_GPL = GPL.map((line) => (line === "" ? "//" : `// ${line}`)).join(
+  "\n",
+);
 const CSS_GPL = ["/*", ...GPL, "*/"].join("\n");
 const GPL_BY_EXT = {
   ts: JS_GPL,

--- a/scripts/add-license/gpl.txt
+++ b/scripts/add-license/gpl.txt
@@ -1,0 +1,15 @@
+DrFed: A web-based platform for developing and debugging ActivityPub apps
+Copyright (C) 2026 DrFed team
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/scripts/add-license/main.mts
+++ b/scripts/add-license/main.mts
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 // oxlint-disable no-console no-magic-numbers
 import { glob, readFile, writeFile } from "node:fs/promises";
 import { dirname, extname, join, relative } from "node:path";
@@ -22,7 +23,7 @@ import { fileURLToPath } from "node:url";
 import GPL from "./gpl.mts";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
-const INCLUDED = ["scripts/", "packages/*/src/"];
+const INCLUDED = ["scripts/", "packages/*/src/", "packages/*/bin/"];
 const EXCLUDED = ["**/dist/"];
 
 type Extension = keyof typeof GPL;
@@ -33,7 +34,7 @@ interface AddLicenseProps {
 
 interface LicenseTarget {
   readonly path: string;
-  readonly extension: Extension;
+  readonly ext: Extension;
 }
 
 interface LicenseCheck extends LicenseTarget {
@@ -41,63 +42,50 @@ interface LicenseCheck extends LicenseTarget {
 }
 
 export default async function addLicense(opt: AddLicenseProps) {
-  const files = await findIncludedFiles();
-  const targets = files
-    .map((path) => ({ path, extension: extensionOf(path) }))
-    .filter(isLicenseTarget);
-  const checks = await Promise.all(targets.map(checkLicense));
-  const missing = checks.filter((check) => !check.hasLicense);
-
-  if (missing.length === 0) {
+  const files = await findTargets().then(filterLicense);
+  if (files.length === 0) {
     process.exit(0);
   }
-
   if (opt.check) {
-    for (const file of missing) {
-      console.log(relative(ROOT, file.path));
-    }
+    console.warn("Licenses are missing from some files:");
+    listFiles(files);
     process.exit(1);
   }
+  console.warn("Added licenses to the files that were missing them:");
+  listFiles(files);
 
-  await Promise.all(missing.map((file) => addLicenseHeader(file)));
+  await Promise.all(files.map(addLicenseHeader));
 }
 
-async function findIncludedFiles(): Promise<string[]> {
-  const patterns = INCLUDED.map((dir) => `${dir}**/*`);
-  const files: string[] = [];
-  for await (const entry of glob(patterns, {
-    cwd: ROOT,
-    exclude: EXCLUDED,
-    withFileTypes: true,
-  })) {
-    if (entry.isFile()) {
-      files.push(join(entry.parentPath, entry.name));
-    }
-  }
-  return files;
-}
+const findTargets = async (): Promise<LicenseTarget[]> =>
+  (await Array.fromAsync(glob(INCLUDED.map(addAsteriskIfDir), GLOB_OPTION)))
+    .filter((entry) => entry.isFile())
+    .map((entry) => join(entry.parentPath, entry.name))
+    .map((path) => ({ path, ext: extensionOf(path) }))
+    .filter(isLicenseTarget);
 
-function extensionOf(path: string): string {
-  return extname(path).slice(1);
-}
+const GLOB_OPTION = {
+  cwd: ROOT,
+  exclude: EXCLUDED,
+  withFileTypes: true,
+} as const;
 
-function isLicenseTarget(
-  file: Readonly<{ path: string; extension: string }>,
-): file is LicenseTarget {
-  return Object.hasOwn(GPL, file.extension);
-}
+const addAsteriskIfDir = (dir: string) =>
+  dir.endsWith("/") ? `${dir}**/*` : dir;
 
-async function readLines(path: string): Promise<string[]> {
-  const content = await readFile(path, { encoding: "utf-8" });
-  return content.split("\n");
-}
+const filterLicense = async (files: LicenseTarget[]): Promise<LicenseCheck[]> =>
+  (await Array.fromAsync(files, checkLicense)).filter(
+    (check) => !check.hasLicense,
+  );
 
-function shebangOffset(lines: readonly string[]): number {
-  return lines[0]?.startsWith("#!") ? 1 : 0;
-}
+const extensionOf = (path: string): string => extname(path).slice(1);
+
+const isLicenseTarget = (
+  file: Readonly<{ path: string; ext: string }>,
+): file is LicenseTarget => Object.hasOwn(GPL, file.ext);
 
 async function checkLicense(target: LicenseTarget): Promise<LicenseCheck> {
-  const header = GPL[target.extension];
+  const header = GPL[target.ext];
   const lines = await readLines(target.path);
   const offset = shebangOffset(lines);
   const headerLineCount = header.split("\n").length;
@@ -106,15 +94,34 @@ async function checkLicense(target: LicenseTarget): Promise<LicenseCheck> {
 }
 
 async function addLicenseHeader(target: LicenseTarget): Promise<void> {
-  const header = GPL[target.extension];
-  const lines = await readLines(target.path);
+  const added = updateLines(GPL[target.ext], await readLines(target.path));
+  await writeFile(target.path, added, { encoding: "utf-8" });
+}
+
+const readLines = async (path: string): Promise<string[]> =>
+  (await readFile(path, { encoding: "utf-8" })).split("\n");
+
+const shebangOffset = (lines: readonly string[]): number =>
+  lines[0]?.startsWith("#!") ? (lines[1]?.trim() === "" ? 2 : 1) : 0;
+
+const updateLines = (header: string, lines: string[]): string =>
+  Array.from(genLines(header, lines)).join("\n");
+
+function* genLines(header: string, lines: string[]): Generator<string> {
   const offset = shebangOffset(lines);
-  const updatedLines = [
-    ...lines.slice(0, offset),
-    ...header.split("\n"),
-    ...lines.slice(offset),
-  ];
-  await writeFile(target.path, updatedLines.join("\n"), { encoding: "utf-8" });
+  yield* lines.slice(0, offset);
+  yield header;
+  const next = lines.at(offset);
+  if (next != null && next.trim() !== "") {
+    yield "";
+  }
+  yield* lines.slice(offset);
+}
+
+function listFiles(files: LicenseTarget[]) {
+  for (const file of files) {
+    console.warn(`  - ${relative(ROOT, file.path)}`);
+  }
 }
 
 if (import.meta.main) {

--- a/scripts/add-license/main.mts
+++ b/scripts/add-license/main.mts
@@ -1,0 +1,21 @@
+import { readFile, glob } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import GPL from "./gpl.mts";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const INCLUDED = ["scripts/", "packages/*/src/"];
+const EXCLUDED = ["**/dist/"];
+
+interface AddLicenseProps {
+  check?: true | undefined;
+}
+
+export default async function addLicense(opt: AddLicenseProps) {
+  //
+}
+
+if (import.meta.main) {
+  await addLicense({});
+}

--- a/scripts/add-license/main.mts
+++ b/scripts/add-license/main.mts
@@ -1,3 +1,18 @@
+// DrFed: A web-based platform for developing and debugging ActivityPub apps
+// Copyright (C) 2026 DrFed team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // oxlint-disable no-console no-magic-numbers
 import { glob, readFile, writeFile } from "node:fs/promises";
 import { dirname, extname, join, relative } from "node:path";

--- a/scripts/add-license/main.mts
+++ b/scripts/add-license/main.mts
@@ -1,21 +1,109 @@
-import { readFile, glob } from "node:fs/promises";
-import { dirname, join } from "node:path";
+// oxlint-disable no-console no-magic-numbers
+import { glob, readFile, writeFile } from "node:fs/promises";
+import { dirname, extname, join, relative } from "node:path";
+import process from "node:process";
 import { fileURLToPath } from "node:url";
 
 import GPL from "./gpl.mts";
 
-const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const INCLUDED = ["scripts/", "packages/*/src/"];
 const EXCLUDED = ["**/dist/"];
+
+type Extension = keyof typeof GPL;
 
 interface AddLicenseProps {
   check?: true | undefined;
 }
 
+interface LicenseTarget {
+  readonly path: string;
+  readonly extension: Extension;
+}
+
+interface LicenseCheck extends LicenseTarget {
+  readonly hasLicense: boolean;
+}
+
 export default async function addLicense(opt: AddLicenseProps) {
-  //
+  const files = await findIncludedFiles();
+  const targets = files
+    .map((path) => ({ path, extension: extensionOf(path) }))
+    .filter(isLicenseTarget);
+  const checks = await Promise.all(targets.map(checkLicense));
+  const missing = checks.filter((check) => !check.hasLicense);
+
+  if (missing.length === 0) {
+    process.exit(0);
+  }
+
+  if (opt.check) {
+    for (const file of missing) {
+      console.log(relative(ROOT, file.path));
+    }
+    process.exit(1);
+  }
+
+  await Promise.all(missing.map((file) => addLicenseHeader(file)));
+}
+
+async function findIncludedFiles(): Promise<string[]> {
+  const patterns = INCLUDED.map((dir) => `${dir}**/*`);
+  const files: string[] = [];
+  for await (const entry of glob(patterns, {
+    cwd: ROOT,
+    exclude: EXCLUDED,
+    withFileTypes: true,
+  })) {
+    if (entry.isFile()) {
+      files.push(join(entry.parentPath, entry.name));
+    }
+  }
+  return files;
+}
+
+function extensionOf(path: string): string {
+  return extname(path).slice(1);
+}
+
+function isLicenseTarget(
+  file: Readonly<{ path: string; extension: string }>,
+): file is LicenseTarget {
+  return Object.hasOwn(GPL, file.extension);
+}
+
+async function readLines(path: string): Promise<string[]> {
+  const content = await readFile(path, { encoding: "utf-8" });
+  return content.split("\n");
+}
+
+function shebangOffset(lines: readonly string[]): number {
+  return lines[0]?.startsWith("#!") ? 1 : 0;
+}
+
+async function checkLicense(target: LicenseTarget): Promise<LicenseCheck> {
+  const header = GPL[target.extension];
+  const lines = await readLines(target.path);
+  const offset = shebangOffset(lines);
+  const headerLineCount = header.split("\n").length;
+  const actualHeader = lines.slice(offset, offset + headerLineCount).join("\n");
+  return { ...target, hasLicense: actualHeader === header };
+}
+
+async function addLicenseHeader(target: LicenseTarget): Promise<void> {
+  const header = GPL[target.extension];
+  const lines = await readLines(target.path);
+  const offset = shebangOffset(lines);
+  const updatedLines = [
+    ...lines.slice(0, offset),
+    ...header.split("\n"),
+    ...lines.slice(offset),
+  ];
+  await writeFile(target.path, updatedLines.join("\n"), { encoding: "utf-8" });
 }
 
 if (import.meta.main) {
-  await addLicense({});
+  await addLicense({
+    check: process.argv.includes("--check") ? true : undefined,
+  });
 }


### PR DESCRIPTION
Adds the `check:license` task; this task checks for files with missing licenses.  
Also adds the `fmt:license` task; this task adds license comments to files missing them.  
`check` depends on `check:license`, and `fmt` depends on `fmt:license`. Therefore, license checks and formatting are automatically applied to all files within the workflow.

Assisted by Claude Code:claude-sonnet-5 and remain the prompt in the message of eee569576354a49f2f01c390edc586747e9f298d.