### PR TITLE
Apply proxy setting for graphql

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -8,6 +8,12 @@
           "fmt.configPath": null
         }
       }
+    },
+    "oxlint": {
+      "binary": {
+        "path": "mise",
+        "arguments": ["exec", "--", "oxlint", "--lsp"]
+      }
     }
   },
   "languages": {

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -97,13 +97,7 @@ const fillOptions = (opt: YogaServerOptions): Required<YogaServerOptions> => ({
   mailer: opt?.mailer ?? mockTransport(),
   emailFrom: opt?.emailFrom ?? "noreply@drfed.org",
   // FIXME: Properly parametrize the following allowlist:
-  origins:
-    opt?.origins ??
-    new Set([
-      "https://drfed.org",
-      "http://localhost:3000",
-      "http://0.0.0.0:3000",
-    ]),
+  origins: opt?.origins ?? new Set(["https://drfed.org"]),
 });
 
 const getAccessToken = (headers: Headers) =>

--- a/packages/web/.env.example
+++ b/packages/web/.env.example
@@ -1,1 +1,0 @@
-VITE_DRFED_URL=http://0.0.0.0:8888/graphql

--- a/packages/web/env.d.ts
+++ b/packages/web/env.d.ts
@@ -1,3 +1,7 @@
+interface ImportMetaEnv {
+  VITE_BACKEND_URL: string;
+}
+
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }

--- a/packages/web/env.d.ts
+++ b/packages/web/env.d.ts
@@ -1,7 +1,3 @@
-interface ImportMetaEnv {
-  readonly VITE_DRFED_URL: string;
-}
-
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }

--- a/packages/web/src/RelayEnvironment.ts
+++ b/packages/web/src/RelayEnvironment.ts
@@ -35,7 +35,13 @@ const fetchFn: FetchFunction = async (params, variables) => {
   if (accessToken !== undefined) {
     headers.Authorization = `Bearer ${accessToken}`;
   }
-  const response = await fetch(import.meta.env.VITE_DRFED_URL, {
+
+  const url = new URL(
+    "/graphql",
+    event?.request.url ?? globalThis.location.href,
+  );
+
+  const response = await fetch(url, {
     method: "POST",
     headers,
     body: JSON.stringify({

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -14,29 +14,34 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import process from "node:process";
+
 import { solidStart } from "@solidjs/start/config";
 import { nitro } from "nitro/vite";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import { cjsInterop } from "vite-plugin-cjs-interop";
 import relay from "vite-plugin-relay-lite";
 
-export default defineConfig(({ command }) => ({
-  plugins: [
-    solidStart(),
-    nitro({
-      routeRules: {
-        "/graphql": {
-          proxy: {
-            to: "http://127.0.0.1:8888/graphql",
-            forwardHeaders: ["accept"],
+export default defineConfig(({ mode, command }) => {
+  const env = loadEnv(mode, process.cwd());
+  return {
+    plugins: [
+      solidStart(),
+      nitro({
+        routeRules: {
+          "/graphql": {
+            proxy: {
+              to: `${env.VITE_BACKEND_URL}/graphql`,
+              forwardHeaders: ["accept"],
+            },
           },
         },
+      }),
+      relay({ codegen: command !== "build" }),
+      {
+        ...cjsInterop({ dependencies: ["relay-runtime"] }),
+        applyToEnvironment: (environment) => environment.name === "ssr",
       },
-    }),
-    relay({ codegen: command !== "build" }),
-    {
-      ...cjsInterop({ dependencies: ["relay-runtime"] }),
-      applyToEnvironment: (environment) => environment.name === "ssr",
-    },
-  ],
-}));
+    ],
+  };
+});

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -23,7 +23,16 @@ import relay from "vite-plugin-relay-lite";
 export default defineConfig(({ command }) => ({
   plugins: [
     solidStart(),
-    nitro(),
+    nitro({
+      routeRules: {
+        "/graphql": {
+          proxy: {
+            to: "http://127.0.0.1:8888/graphql",
+            forwardHeaders: ["accept"],
+          },
+        },
+      },
+    }),
     relay({ codegen: command !== "build" }),
     {
       ...cjsInterop({ dependencies: ["relay-runtime"] }),


### PR DESCRIPTION
Closes https://github.com/fedify-dev/drfed/issues/45

Issue suggests to use Caddy, however nitro 3 support proxy in build. Now https://localhost:3000/graphql handles to https://localhost:8888/graphql, So we can use yoga sever and relative path on relay fetch.