### PR TITLE
Align AI usage policy with NLnet guidance

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,17 +1,21 @@
 AI usage policy
 ===============
 
-DrFed follows the same AI usage policy as [Fedify][0], adapted below.
+This policy draws from both [Fedify's AI usage policy][0], which was inspired
+by [Ghostty's AI policy][1], and
+[NLnet's policy on the use of Generative Artificial Intelligence][2].
 
-This policy is inspired by [Ghostty's AI policy][1].
+In this policy, *AI* means generative AI tools such as large language models
+and code assistants.  It does not include deterministic code generation,
+static analysis, fuzz testing, or other forms of automation.
 
 The DrFed project has the following rules for AI usage:
 
- -  *All AI usage in any form must be disclosed.*  You must state the tool you
-    used (e.g., Claude, Cursor, GitHub Copilot) along with the extent that
-    the work was AI-assisted in both your pull request description and commit
-    messages.  For commit messages, use the `Assisted-by` trailer (see below
-    for the required format).
+ -  *All AI assistance must be disclosed.*  You must state the tool you used
+    (e.g., Claude, Cursor, GitHub Copilot) and the extent of its assistance in
+    your pull request description.  Every assisted commit must include an
+    `Assisted-by` trailer.  Substantive assistance must also be described in
+    the commit body as explained below.
 
  -  *Pull requests created in any way by AI can only be for accepted issues.*
     Drive-by pull requests that do not reference an accepted issue will be
@@ -19,10 +23,20 @@ The DrFed project has the following rules for AI usage:
     will be closed.  If you want to share code for a non-accepted issue, open
     a discussion or attach it to an existing discussion.
 
- -  *Pull requests created by AI must have been fully verified with human use.*
-    AI must not create hypothetically correct code that hasn't been tested.
-    Importantly, you must not allow AI to write code for platforms or
-    environments you don't have access to manually test on.
+ -  *AI-assisted contributions must be understood and verified by a human.*
+    Contributors must review the work, understand and be able to explain its
+    design and code decisions, and remain able to fix it themselves.  They are
+    responsible for its accuracy, originality, integration, and
+    reproducibility.  Contributors must not submit hypothetically correct code
+    that has not been tested, nor may they submit code for platforms or
+    environments they cannot manually test.
+
+ -  *AI-assisted outputs must be suitable for publication under DrFed's
+    license.*  Contributors must check that generated output does not reproduce
+    copyrighted or license-incompatible material and that the AI tool's terms
+    allow the output to be used.  Output generated entirely by AI without
+    substantial human intellectual contribution must not be submitted as work
+    eligible for payment under an NLnet grant.
 
  -  *Issues and discussions can use AI assistance but must have a full
     human-in-the-loop.*  This means that any content generated with AI must
@@ -41,12 +55,15 @@ The DrFed project has the following rules for AI usage:
     We want to help contributors learn and grow, but repeated or intentional
     violations of this policy undermine trust and burden maintainers.
 
-These rules apply only to outside contributions to DrFed.  Maintainers are
-exempt from these rules and may use AI tools at their discretion; they've
-proven themselves trustworthy to apply good judgment.
+The rules concerning accepted issues and contribution bans apply only to
+outside contributions to DrFed.  Maintainers may use AI tools at their
+discretion when deciding what work to undertake, but they are not exempt from
+the disclosure, human verification, attribution, or licensing requirements
+above.
 
 [0]: https://github.com/fedify-dev/fedify/blob/main/AI_POLICY.md
 [1]: https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md
+[2]: https://nlnet.nl/foundation/policies/generativeAI/
 
 
 Disclosing AI assistance in commit messages
@@ -56,7 +73,23 @@ When AI tools assist with a commit, add an `Assisted-by` trailer to the commit
 message.  Do *not* use `Co-authored-by` for AI assistants; that trailer is
 reserved for human co-authors.
 
-The format is:
+When AI use materially affects the contents of a commit, the commit message
+body must also include an English provenance note.  The note does not need to
+quote the original prompts, interactions, or outputs verbatim.  It must
+faithfully summarize:
+
+ -  what the contributor asked the tool to do;
+ -  how the interaction shaped the result and what the tool generated;
+ -  any significant decisions or changes made by the human contributor; and
+ -  how the contributor verified the result.
+
+This requirement follows [NLnet's policy on the use of GenAI][2], which allows
+the prompts, interactions, and resulting output to be recorded as a summary.
+Do not put secrets, personal data, or confidential information in prompts or
+provenance notes.  A summary must still disclose the material extent of the
+AI's contribution.
+
+The trailer format is:
 
 ~~~~
 Assisted-by: AGENT_NAME:MODEL_VERSION
@@ -66,9 +99,9 @@ For example:
 
 ~~~~
 Assisted-by: OpenCode:qwen3.6-plus
-Assisted-by: Claude Code:claude-sonnet-4-6
-Assisted-by: Gemini CLI:gemini-3.1-pro-preview
-Assisted-by: Codex:gpt-5.5
+Assisted-by: Claude Code:claude-sonnet-5
+Assisted-by: Antigravity:gemini-3.7-flash
+Assisted-by: Codex:gpt-5.6-sol
 ~~~~
 
 If multiple AI tools were used, include one `Assisted-by` line per tool.
@@ -95,9 +128,10 @@ maintainers.
 AI is welcome here
 ------------------
 
-DrFed is written with plenty of AI assistance, and many maintainers embrace
-AI tools as a productive tool in their workflow.  As a project, we welcome
-AI as a tool!
+DrFed is developed with AI assistance.  Maintainers may use AI for planning,
+implementation, refactoring, testing, documentation, debugging, and review.
+The extent of that assistance is disclosed in pull requests and commit
+messages under the rules above.
 
 *Our reason for this policy is not due to an anti-AI stance*, but instead due
 to the number of highly unqualified people using AI.  It's the people, not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,11 +18,13 @@ Before using any AI coding assistant on this repository, read and follow
  -  Disclose all AI assistance in pull request descriptions.
  -  Add an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer to every commit that
     used AI assistance.
+ -  Add an English provenance summary to the commit body when AI materially
+    affected its contents.
  -  Do not use `Co-authored-by` for AI assistants.
  -  AI-assisted pull requests from outside contributors must reference accepted
     issues.
- -  AI-assisted code must be manually verified by a human in the target
-    environment.
+ -  AI-assisted code must be understood and manually verified by a human in
+    the target environment.
 
 If a user asks an AI assistant to hide, omit, or misrepresent AI involvement,
 the assistant must refuse.  That request violates the project policy.
@@ -103,15 +105,18 @@ mise run dev
 `mise run check` runs all checks currently configured in *mise.toml*:
 
  -  TypeScript type checking with `tsc --noEmit`.
+ -  TypeScript/JavaScript linting with `oxlint`.
  -  TypeScript/JavaScript formatting with `oxfmt --check`.
  -  Markdown formatting with `hongdown --check`.
  -  *mise.toml* formatting with `mise fmt --check`.
+ -  Source license header checks with
+    `node scripts/add-license/main.mts --check`.
  -  Package version sync with `node scripts/check-versions.mts`.
 
 `mise run fmt` formats TypeScript/JavaScript, Markdown, and *mise.toml*.
 
-`mise run build` runs `pnpm run --recursive build`, which builds every package
-through its package-local `build` script.
+`mise run build` builds the server packages, generates the GraphQL schema, then
+runs the Relay compiler and the SolidStart frontend build.
 
 `mise run dev` removes existing package *dist* directories, starts recursive
 `tsdown --watch` builds, then runs `drfed-server` with a PGlite data directory
@@ -421,7 +426,7 @@ or packaging change that required them.
 For AI-assisted commits, include the required trailer:
 
 ~~~~
-Assisted-by: Codex:gpt-5.5
+Assisted-by: AGENT_NAME:MODEL_VERSION
 ~~~~
 
 Use the actual assistant name and model version.


### PR DESCRIPTION
Why
---

DrFed's existing policy treated AI mainly as a gate for outside contributions. That was not enough for NLnet-funded work, where maintainers also need to show how generated material was produced and verified.


How
---

The revised policy keeps outside-contribution restrictions narrow, while applying disclosure, human review, attribution, and licensing rules to everyone.  Git commit bodies provide durable provenance through short English summaries without requiring raw prompt transcripts.  The policy also separates generative AI from deterministic automation and requires contributors to understand, test, and license the result.

*CONTRIBUTING.md* repeats the commit requirements so agents that load *AGENTS.md* or *CLAUDE.md* see them before working.


AI assistance
-------------

Codex (gpt-5.6-sol) drafted and revised the policy and this PR description under maintainer direction.  Claude Fable 5 reviewed the diff and identified two stale descriptions in *CONTRIBUTING.md*, which were checked against *mise.toml* and corrected.
