### PR TITLE
Enforce explicit extensions on local imports with Oxlint

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -54,6 +54,11 @@
     "oxc/no-rest-spread-properties": "off",
     "import/consistent-type-specifier-style": "off",
     "import/exports-last": "off",
+    "import/extensions": [
+      "error",
+      "always",
+      { "checkTypeImports": true, "ignorePackages": true }
+    ],
     "import/group-exports": "off",
     "import/max-dependencies": ["warn", { "max": 20 }],
     "import/no-default-export": "off",

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,8 @@
 min_version = "2026.6.10"
 
+[settings]
+experimental = true
+
 [tools]
 "aqua:dahlia/hongdown" = "0.4.3"
 "github:nushell/nushell" = "0.114.1"

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -23,7 +23,7 @@ import "./drfed.css";
 import "./app.css";
 import { RelayEnvironmentProvider } from "solid-relay";
 
-import { createRelayEnvironment } from "./RelayEnvironment";
+import { createRelayEnvironment } from "./RelayEnvironment.ts";
 
 export default function App() {
   const environment = createRelayEnvironment();

--- a/packages/web/src/routes/confirm/[token].tsx
+++ b/packages/web/src/routes/confirm/[token].tsx
@@ -18,8 +18,8 @@ import { action, useAction, useParams, useSearchParams } from "@solidjs/router";
 import { commitMutation, graphql } from "relay-runtime";
 import { Show, createSignal, onMount } from "solid-js";
 
-import { createRelayEnvironment } from "~/RelayEnvironment";
-import { setSessionCookie } from "~/session";
+import { createRelayEnvironment } from "~/RelayEnvironment.ts";
+import { setSessionCookie } from "~/session.ts";
 
 import type { CompleteLoginChallenge } from "./__generated__/CompleteLoginChallenge.graphql.ts";
 

--- a/packages/web/src/routes/index.tsx
+++ b/packages/web/src/routes/index.tsx
@@ -19,7 +19,7 @@ import { graphql } from "relay-runtime";
 import { Show } from "solid-js";
 import { createLazyLoadQuery } from "solid-relay";
 
-import type { HomeViewerQuery } from "./__generated__/HomeViewerQuery.graphql";
+import type { HomeViewerQuery } from "./__generated__/HomeViewerQuery.graphql.ts";
 
 const homeViewerQuery = graphql`
   query HomeViewerQuery {

--- a/packages/web/src/routes/sign-in.tsx
+++ b/packages/web/src/routes/sign-in.tsx
@@ -19,7 +19,7 @@ import { graphql } from "relay-runtime";
 import { Show, createSignal } from "solid-js";
 import { createMutation } from "solid-relay";
 
-import type { SignInMutation } from "./__generated__/SignInMutation.graphql";
+import type { SignInMutation } from "./__generated__/SignInMutation.graphql.ts";
 
 import "./sign-in.css";
 

--- a/packages/web/src/routes/workspace/create/instance.tsx
+++ b/packages/web/src/routes/workspace/create/instance.tsx
@@ -21,7 +21,7 @@ import { graphql } from "relay-runtime";
 import { Show, createSignal } from "solid-js";
 import { createMutation } from "solid-relay";
 
-import type { CreateInstanceMutation } from "./__generated__/CreateInstanceMutation.graphql";
+import type { CreateInstanceMutation } from "./__generated__/CreateInstanceMutation.graphql.ts";
 
 const createInstanceMutation = graphql`
   mutation CreateInstanceMutation($slug: String!) {

--- a/packages/web/src/routes/workspace/index.tsx
+++ b/packages/web/src/routes/workspace/index.tsx
@@ -18,8 +18,8 @@ import { graphql } from "relay-runtime";
 import { For, Show } from "solid-js";
 import { createFragment, createLazyLoadQuery } from "solid-relay";
 
-import type { InstanceSummary_instance$key } from "./__generated__/InstanceSummary_instance.graphql";
-import type { WorkspaceQuery } from "./__generated__/WorkspaceQuery.graphql";
+import type { InstanceSummary_instance$key } from "./__generated__/InstanceSummary_instance.graphql.ts";
+import type { WorkspaceQuery } from "./__generated__/WorkspaceQuery.graphql.ts";
 
 const workspaceQuery = graphql`
   query WorkspaceQuery {


### PR DESCRIPTION
*CONTRIBUTING.md* already asks for explicit *.ts* extensions on local source imports, but nothing checked it, so a few imports in *packages/web* had drifted. Rather than grep for them by hand, I turned on Oxlint's `import/extensions` rule and let it produce the list.

`ignorePackages: true` is what makes the rule usable. Without it every bare specifier counts as missing an extension, so `node:assert/strict` and `@drfed/models/schema` fail alongside the real cases: 135 errors instead of 8. With it, only relative and `~/*` imports are checked, and Oxlint resolves the tsconfig `paths` mapping itself, so `~/session` still counts as local. `checkTypeImports: true` covers type-only imports, where most of the drift was.

Relay needed a decision. relay-compiler emits *X.graphql.ts*, so `./__generated__/X.graphql` is extensionless as far as Oxlint can tell. One route already spelled out `.graphql.ts`, so I matched it in the other five rather than exempt generated imports in the config.

The rule only checks imports it can resolve, so those artifacts stay unchecked until relay-compiler has run. `check:types` already has that precondition.

I also enabled mise's experimental settings in *mise.toml*, since `[deps.pnpm]` otherwise breaks every mise task, including the generated pre-commit hook.

I ran `mise run check`, `mise run build`, and `mise run test`; all passed.


AI usage disclosure
-------------------

Claude Code (Claude Opus 5) chose the rule options, updated the imports, and drafted both commit messages and this description. Codex (gpt-5.6-sol) and Claude Code (Claude Fable 5) then reviewed the diff and suggested no changes, so no commit carries an `Assisted-by` trailer for them. I read the diff and checked the option semantics against Oxlint's documentation.
